### PR TITLE
Migrate to new Application() entry point

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,41 +1,38 @@
-import { audio, loader, state, device, video, plugin, pool } from "melonjs";
+import { Application, audio, loader, state, plugin, pool } from "melonjs";
 import TitleScreen from "./scripts/stage/title";
 import PlayScreen from "./scripts/stage/play";
 import PlayerEntity from "./scripts/renderables/player";
 import DataManifest from "./manifest";
 import "./index.css";
 
-device.onReady(() => {
+// create a new melonJS Application
+const app = new Application(1218, 562, {
+    parent: "screen",
+    scale: "auto",
+});
 
-    // initialize the display canvas once the device/browser is ready
-    if (!video.init(1218, 562, {parent : "screen", scale : "auto"})) {
-        alert("Your browser does not support HTML5 canvas.");
-        return;
-    }
+// initialize the audio
+audio.init("mp3,ogg");
 
-    // initialize the audio
-    audio.init("mp3,ogg");
+// allow cross-origin for image/texture loading
+loader.setOptions({ crossOrigin: "anonymous" });
 
-    // allow cross-origin for image/texture loading
-    loader.setOptions({crossOrigin: "anonymous"});
-
-    // initialize the debug plugin in development mode
-    if (import.meta.env.DEV) {
-        import("@melonjs/debug-plugin").then((debugPlugin) => {
-            plugin.register(debugPlugin.DebugPanelPlugin, "debugPanel");
-        });
-    }
-
-    // set and load all resources
-    loader.preload(DataManifest, () => {
-        // set the user defined game stages
-        state.set(state.MENU, new TitleScreen());
-        state.set(state.PLAY, new PlayScreen());
-
-        // add our player entity in the entity pool
-        pool.register("mainPlayer", PlayerEntity);
-
-        // start the game
-        state.change(state.PLAY, false);
+// initialize the debug plugin in development mode
+if (import.meta.env.DEV) {
+    import("@melonjs/debug-plugin").then((debugPlugin) => {
+        plugin.register(debugPlugin.DebugPanelPlugin, "debugPanel");
     });
+}
+
+// set and load all resources
+loader.preload(DataManifest, () => {
+    // set the user defined game stages
+    state.set(state.MENU, new TitleScreen());
+    state.set(state.PLAY, new PlayScreen());
+
+    // add our player entity in the entity pool
+    pool.register("mainPlayer", PlayerEntity);
+
+    // start the game
+    state.change(state.PLAY, false);
 });

--- a/src/scripts/stage/play.ts
+++ b/src/scripts/stage/play.ts
@@ -1,20 +1,20 @@
-import { Stage, game, ColorLayer, BitmapText } from "melonjs";
+import { type Application, Stage, ColorLayer, BitmapText } from "melonjs";
 
 class PlayScreen extends Stage {
     /**
      *  action to perform on state change
      */
-    onResetEvent() {
+    onResetEvent(app: Application) {
         // add a gray background to the default Stage
-        game.world.addChild(new ColorLayer("background", "#202020"));
+        app.world.addChild(new ColorLayer("background", "#202020"));
 
         // add a font text display object
-        game.world.addChild(new BitmapText(game.viewport.width / 2, game.viewport.height / 2, {
-            font : "PressStart2P",
-            size : 4.0,
-            textBaseline : "middle",
-            textAlign : "center",
-            text : "Hello World !"
+        app.world.addChild(new BitmapText(app.viewport.width / 2, app.viewport.height / 2, {
+            font: "PressStart2P",
+            size: 4.0,
+            textBaseline: "middle",
+            textAlign: "center",
+            text: "Hello World!",
         }));
     }
 }

--- a/src/scripts/stage/title.ts
+++ b/src/scripts/stage/title.ts
@@ -1,17 +1,17 @@
-import { Stage } from "melonjs";
+import { type Application, Stage } from "melonjs";
 
 class TitleScreen extends Stage {
     /**
      *  action to perform on state change
      */
-    onResetEvent() {
+    onResetEvent(app: Application) {
         // TODO
     }
 
     /**
      *  action to perform when leaving this screen (state change)
      */
-    onDestroyEvent() {
+    onDestroyEvent(app: Application) {
         // TODO
     }
 }


### PR DESCRIPTION
## Summary

Migrate the boilerplate from the legacy `device.onReady()` + `video.init()` pattern to the new `Application` constructor.

## Changes

- **index.ts**: Replace `device.onReady()` + `video.init()` with `new Application(1218, 562, { ... })`
- **play.ts**: `onResetEvent(app)` uses `app.world` and `app.viewport` instead of `game` singleton
- **title.ts**: `onResetEvent(app)` and `onDestroyEvent(app)` receive the Application instance

## Why

`new Application()` is the recommended entry point since melonJS 18.3. It auto-calls `boot()`, creates the renderer/world/viewport, and starts the game loop in a single call. `video.init()` and `device.onReady()` are deprecated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)